### PR TITLE
Allow statsd reporting of instances of Num type class

### DIFF
--- a/src/Network/DogStatsd.hs
+++ b/src/Network/DogStatsd.hs
@@ -34,20 +34,20 @@ decrement client stat = count client stat (-1)
 count :: UdpClient -> Stat -> Int -> Tags -> IO ()
 count client stat value tags = void . send client $ fmtDogStatsdDatagram stat value Count tags
 
-gauge :: UdpClient -> Stat -> Int -> Tags -> IO ()
+gauge :: (Show a, Num a) => UdpClient -> Stat -> a -> Tags -> IO ()
 gauge client stat value tags = void . send client $ fmtDogStatsdDatagram stat value Gauge tags
 
 timing :: UdpClient -> Stat -> Millisecond -> Tags -> IO ()
 timing client stat value tags = void . send client $ fmtDogStatsdDatagram stat (fromIntegral value) Timing tags
 
-histogram :: UdpClient -> Stat -> Int -> Tags -> IO ()
+histogram :: (Show a, Num a) => UdpClient -> Stat -> a -> Tags -> IO ()
 histogram client stat value tags = void . send client $ fmtDogStatsdDatagram stat value Histogram tags
 
 fmtTag :: (Name, Value) -> String
 fmtTag (a, "") = a
 fmtTag (a, b) = a ++ ":" ++ b
 
-fmtDogStatsdDatagram :: Stat -> Int -> Type -> Tags -> String
+fmtDogStatsdDatagram :: (Show a, Num a) => Stat -> a -> Type -> Tags -> String
 fmtDogStatsdDatagram stat value statType [] = fmtDatagram stat value statType
 fmtDogStatsdDatagram stat value statType tags =
   let statsdDatagram = fmtDatagram stat value statType

--- a/src/Network/Statsd.hs
+++ b/src/Network/Statsd.hs
@@ -42,14 +42,14 @@ decrement client stat = count client stat (-1)
 count :: UdpClient -> Stat -> Int -> IO ()
 count client stat value = void . send client $ fmtDatagram stat value Count
 
-gauge :: UdpClient -> Stat -> Int -> IO ()
+gauge :: (Show a, Num a) => UdpClient -> Stat -> a -> IO ()
 gauge client stat value = void . send client $ fmtDatagram stat value Gauge
 
 timing :: UdpClient -> Stat -> Millisecond -> IO ()
 timing client stat value = void . send client $ fmtDatagram stat (fromIntegral value) Timing
 
-histogram :: UdpClient -> Stat -> Int -> IO ()
+histogram :: (Show a, Num a) => UdpClient -> Stat -> a -> IO ()
 histogram client stat value = void . send client $ fmtDatagram stat value Histogram
 
-fmtDatagram :: Stat -> Int -> Type -> String
+fmtDatagram:: (Show a, Num a) => Stat -> a -> Type -> String
 fmtDatagram stat value statType = printf "%s:%s|%s" stat (show value) (show statType)

--- a/statsd-client.cabal
+++ b/statsd-client.cabal
@@ -1,5 +1,5 @@
 name: statsd-client
-version: 0.3.0.0
+version: 0.3.0.1
 cabal-version: >=1.10
 build-type: Simple
 license: MIT


### PR DESCRIPTION
This patch relaxes the `Int` type constraints on `gauge` and `histogram` reporting functions. As far as I can tell, there is no reason to confine these reporting metrics to `Int`, as statsd does not impose a type restriction on the value of those metrics.

I've left `count` and `timing` unchanged, as those use cases seem to rely on `Int` and `Millisecond` respectively, and it's not immediately clear what relaxing those type constraints might have on statsd operations.